### PR TITLE
Fix problem with context manager exit

### DIFF
--- a/scrapy_aiohttp_downloader/handler.py
+++ b/scrapy_aiohttp_downloader/handler.py
@@ -9,7 +9,7 @@ from scrapy.responsetypes import responsetypes
 from scrapy.spiders import Spider
 from scrapy.utils.defer import deferred_f_from_coro_f, deferred_from_coro
 from scrapy.utils.reactor import verify_installed_reactor
-from twisted.internet.defer import Deferred
+from twisted.internet.defer import Deferred, inlineCallbacks
 
 from scrapy_aiohttp_downloader.parser import RequestParser
 
@@ -62,10 +62,11 @@ class AioHTTPDownloadHandler(HTTPDownloadHandler):
             request=request,
         )
 
+    @inlineCallbacks
     def close(self):  # type: ignore
         yield self._close()
         yield super().close()
 
     @deferred_f_from_coro_f
     async def _close(self) -> None:
-        await self.client.__aexit__()  # type: ignore
+        await self.client.__aexit__(None, None, None)  # type: ignore


### PR DESCRIPTION
I use your module in my project. I have met a problem with closing of aiohttp client session:
```
2024-10-22 15:59:26 [scrapy.core.engine] INFO: Closing spider (finished)
2024-10-22 15:59:26 [scrapy.core.engine] INFO: Spider closed (finished)
2024-10-22 15:59:27 [asyncio] ERROR: Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x000001DE3795D580>
2024-10-22 15:59:27 [asyncio] ERROR: Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x000001DE37AC0410>
2024-10-22 15:59:27 [asyncio] ERROR: Unclosed connector
connections: ['[(<aiohttp.client_proto.ResponseHandler object at 0x000001DE37ADDD90>, 1111928.671)]']
connector: <aiohttp.connector.TCPConnector object at 0x000001DE37AC1D60>
```
I fixed this error using [ScrapyPlaywrightDownloadHandler](https://github.com/scrapy-plugins/scrapy-playwright/blob/a28631a020f25b1f02e187d2bf21a546973ccd6d/scrapy_playwright/handler.py#L135) class as an example.